### PR TITLE
adding main_menu to header

### DIFF
--- a/layouts/base.twig
+++ b/layouts/base.twig
@@ -11,7 +11,7 @@
 			{% block header %}
 				<a class="logo" href="{{site.url}}" rel="home">{{site.name}}</a>
 				<nav id="nav-main" class="nav-main" role="navigation">
-					{% include "menu.twig" with {'menu': menu.get_items} %}
+					{% include "menu.twig" with {'menu': main_menu.get_items} %}
 				</nav><!-- .nav-main -->
 			{% endblock %}
 		</header>


### PR DESCRIPTION
Maybe a bit overkill for a PR and I may well be wrong, but noticed a small issue. Just added main_menu, to be inline with the potential Timber context..

27: includes/timber.php `// $context['main_menu'] = new TimberMenu('main-menu');`
